### PR TITLE
`MAX_IMAGE_PIXELS` is now `None`

### DIFF
--- a/convert_image.py
+++ b/convert_image.py
@@ -9,10 +9,9 @@ from skimage import io
 import cv2
 import PIL
 from PIL import Image
-PIL.Image.MAX_IMAGE_PIXELS = 933120000
+PIL.Image.MAX_IMAGE_PIXELS = None
 
 from utils import numpy2tiff
-
 
 def set_args():
     parser = argparse.ArgumentParser(description = "Convert Image to Pyramidal TIFF")


### PR DESCRIPTION
Setting the MAX_IMAGE_PIXELS value to None is better because it removes the maximum limit on the image size, which provides more flexibility for loading images of any size without encountering an exception.