### PR TITLE
`MAX_IMAGE_PIXELS` is now `None`

### DIFF
--- a/convert_slide.py
+++ b/convert_slide.py
@@ -8,7 +8,7 @@ import numpy as np
 from skimage import io
 import PIL
 from PIL import Image
-PIL.Image.MAX_IMAGE_PIXELS = 933120000
+PIL.Image.MAX_IMAGE_PIXELS = None
 
 from utils import numpy2tiff
 


### PR DESCRIPTION
Setting the `MAX_IMAGE_PIXELS` value to `None` is better because it removes the maximum limit on the image size, which provides more flexibility for loading images of any size without encountering an exception.